### PR TITLE
Modified the behavior of assignment to not modify the status code.

### DIFF
--- a/walk.c
+++ b/walk.c
@@ -180,7 +180,6 @@ top:	sigchk();
 		if (n->u[0].p == NULL)
 			rc_error("null variable name");
 		assign(glom(n->u[0].p), glob(glom(n->u[1].p)), FALSE);
-		set(TRUE);
 		break;
 	case nPipe:
 		dopipe(n);


### PR DESCRIPTION
As discussed at [https://github.com/rakitzis/rc/pull/83](url)
This is (somewhat) consistent with the behavior of bash/POSIX shell. Before, it was impossible (to me) to get the status code when making an assigment from a command substitution.

Now you can have really neat C-like code like this:
```
if ( response=`{make-http-request $url} ) {
        echo $response
} else {
        echo 'an error occurred' >[1=2]
        echo $response
}
```
I've pulled your fork and everything seems to work as expected.